### PR TITLE
24.2.1 Correct post composer switchover issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pcr/zf1-future",
     "description": "Zend Framework 1. The aim is to keep ZF1 working with the latest PHP versions",
     "type": "library",
-    "version": "24.2.0",
+    "version": "24.2.1",
     "keywords": [
         "framework",
         "zf1"

--- a/library/Zend/Barcode/Renderer/Image.php
+++ b/library/Zend/Barcode/Renderer/Image.php
@@ -345,7 +345,9 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
     public function render()
     {
         $this->draw();
-        header("Content-Type: image/" . $this->_imageType);
+        // PCR360-11102: The Content-Type header is breaking HTML barcodes, causing the iframe content to render with
+        // the URL for the report as the src
+        // header("Content-Type: image/" . $this->_imageType);
         $functionName = 'image' . $this->_imageType;
         call_user_func($functionName, $this->_resource);
         @imagedestroy($this->_resource);

--- a/library/Zend/Barcode/Renderer/Image.php
+++ b/library/Zend/Barcode/Renderer/Image.php
@@ -345,8 +345,11 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
     public function render()
     {
         $this->draw();
-        // PCR360-11102: The Content-Type header is breaking HTML barcodes, causing the iframe content to render with
-        // the URL for the report as the src
+        /**
+         * @see PCR360-11102
+         * The Content-Type header is breaking HTML barcodes, causing the iframe content to render
+         * with the URL for the report as the src
+         */
         // header("Content-Type: image/" . $this->_imageType);
         $functionName = 'image' . $this->_imageType;
         call_user_func($functionName, $this->_resource);

--- a/library/Zend/View/Helper/Json.php
+++ b/library/Zend/View/Helper/Json.php
@@ -73,7 +73,8 @@ class Zend_View_Helper_Json extends Zend_View_Helper_Abstract
         }
 
         if ($encodeData) {
-            $data = Zend_Json::encode($data, null, $options);
+            // Zend_Json::encode uses dynamic property assignment which is deprecated.
+            $data = json_encode($data);
         }
         if (!$keepLayouts) {
             require_once 'Zend/Layout.php';


### PR DESCRIPTION
24.2.1 PCR360-11508 Update Zend_View_Helper_Json::json to use json_encode instead of Zend_Json::encode to eliminate 

deprecated dynamic property assignment messages

24.2.1 PCR360-11256 Barcode Function - Custom Report Builder Phase 1

Reverts to pre-composer switch Zend_Barcode_Renderer_Image::render modifications
