### PR TITLE
24.2.1 PCR360-11526 Temp files should only be created in /tmp when AP_TEMP_DIR is undefined

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pcr/zf1-future",
     "description": "Zend Framework 1. The aim is to keep ZF1 working with the latest PHP versions",
     "type": "library",
-    "version": "24.2.1",
+    "version": "24.2.2",
     "keywords": [
         "framework",
         "zf1"
@@ -26,14 +26,13 @@
     "include-path": [
         "library/"
     ],
-    "config": {
-        "bin-dir": "bin"
-    },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.12.x-dev",
-            "dev-PCR360-11213-PHP8.3-support": "24.2.x-dev"
+            "dev-bugfix/PCR360-11526": "24.2.x-dev"
         }
+    },
+    "config": {
+        "bin-dir": "bin"
     },
     "require-dev": {
         "phpunit/phpunit": "^7|^8|^9",

--- a/library/Zend/Cache/Backend.php
+++ b/library/Zend/Cache/Backend.php
@@ -171,7 +171,6 @@ class Zend_Cache_Backend
      */
     public function getTmpDir()
     {
-        $tmpdir = [];
         foreach ([$_ENV, $_SERVER] as $tab) {
             foreach (['TMPDIR', 'TEMP', 'TMP', 'windir', 'SystemRoot'] as $key) {
                 if (isset($tab[$key]) && is_string($tab[$key])) {
@@ -193,6 +192,15 @@ class Zend_Cache_Backend
                 return $dir;
             }
         }
+
+        // If APP_TMP_DIR is defined, use that and avoid permissions issues.
+        if (defined('APP_TEMP_DIR')) {
+            $dir = APP_TEMP_DIR;
+            if ($this->_isGoodTmpDir($dir)) {
+                return $dir;
+            }
+        }
+
         if (function_exists('sys_get_temp_dir')) {
             $dir = sys_get_temp_dir();
             if ($this->_isGoodTmpDir($dir)) {

--- a/library/Zend/Cloud/StorageService/Adapter/FileSystem.php
+++ b/library/Zend/Cloud/StorageService/Adapter/FileSystem.php
@@ -62,7 +62,8 @@ class Zend_Cloud_StorageService_Adapter_FileSystem implements Zend_Cloud_Storage
         if (isset($options[self::LOCAL_DIRECTORY])) {
             $this->_directory = $options[self::LOCAL_DIRECTORY];
         } else {
-            $this->_directory = realpath(sys_get_temp_dir());
+            // Only use sys_get_temp_dir() if APP_TEMP_DIR is undefined
+            $this->_directory = realpath(defined('APP_TEMP_DIR') ? APP_TEMP_DIR : sys_get_temp_dir());
         }
     }
 

--- a/library/Zend/File/Transfer/Adapter/Abstract.php
+++ b/library/Zend/File/Transfer/Adapter/Abstract.php
@@ -1383,7 +1383,8 @@ abstract class Zend_File_Transfer_Adapter_Abstract
         if (null === $this->_tmpDir) {
             $tmpdir = [];
             if (function_exists('sys_get_temp_dir')) {
-                $tmpdir[] = sys_get_temp_dir();
+                // Only use sys_get_temp_dir() if APP_TEMP_DIR is undefined
+                $tmpdir[] = defined('APP_TEMP_DIR') ? APP_TEMP_DIR : sys_get_temp_dir();
             }
 
             if (!empty($_ENV['TMP'])) {

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -987,8 +987,13 @@ class Zend_Http_Client
         $this->_stream_name = $this->config['output_stream'];
         if(!is_string($this->_stream_name)) {
             // If name is not given, create temp name
-            $this->_stream_name = tempnam(isset($this->config['stream_tmp_dir'])?$this->config['stream_tmp_dir']:sys_get_temp_dir(),
-                 'Zend_Http_Client');
+            $this->_stream_name = tempnam(
+                $this->config['stream_tmp_dir'] ?? (
+                    // Only use sys_get_temp_dir() if APP_TEMP_DIR is undefined
+                    defined('APP_TEMP_DIR') ? APP_TEMP_DIR : sys_get_temp_dir()
+                ),
+                'Zend_Http_Client'
+            );
         }
 
         if (false === ($fp = @fopen($this->_stream_name, "w+b"))) {

--- a/library/Zend/Mail/Transport/File.php
+++ b/library/Zend/Mail/Transport/File.php
@@ -69,7 +69,8 @@ class Zend_Mail_Transport_File extends Zend_Mail_Transport_Abstract
 
         // Making sure we have some defaults to work with
         if (!isset($options['path'])) {
-            $options['path'] = sys_get_temp_dir();
+            // Only use sys_get_temp_dir() if APP_TEMP_DIR is undefined
+            $options['path'] = defined('APP_TEMP_DIR') ? APP_TEMP_DIR : sys_get_temp_dir();
         }
         if (!isset($options['callback'])) {
             $options['callback'] = [$this, 'defaultCallback'];

--- a/library/Zend/OpenId/Consumer/Storage/File.php
+++ b/library/Zend/OpenId/Consumer/Storage/File.php
@@ -58,7 +58,8 @@ class Zend_OpenId_Consumer_Storage_File extends Zend_OpenId_Consumer_Storage
             if (empty($tmp)) {
                 $tmp = getenv('TEMP');
                 if (empty($tmp)) {
-                    $tmp = "/tmp";
+                    // Only use /tmp if APP_TEMP_DIR is undefined
+                    $tmp = defined('APP_TEMP_DIR') ? APP_TEMP_DIR : '/tmp';
                 }
             }
             $user = get_current_user();

--- a/library/Zend/OpenId/Provider/Storage/File.php
+++ b/library/Zend/OpenId/Provider/Storage/File.php
@@ -58,7 +58,8 @@ class Zend_OpenId_Provider_Storage_File extends Zend_OpenId_Provider_Storage
             if (empty($tmp)) {
                 $tmp = getenv('TEMP');
                 if (empty($tmp)) {
-                    $tmp = "/tmp";
+                    // Only use /tmp if APP_TEMP_DIR is undefined
+                    $tmp = defined('APP_TEMP_DIR') ? APP_TEMP_DIR : '/tmp';
                 }
             }
             $user = get_current_user();

--- a/library/Zend/Service/SlideShare.php
+++ b/library/Zend/Service/SlideShare.php
@@ -196,7 +196,8 @@ class Zend_Service_SlideShare
                     'lifetime'                => 43200,
                     'automatic_serialization' => true
                 ],
-                ['cache_dir' => '/tmp']
+                // Only use /tmp if APP_TEMP_DIR is undefined
+                ['cache_dir' => defined('APP_TEMP_DIR') ? APP_TEMP_DIR : '/tmp']
             );
 
             $this->setCacheObject($cache);

--- a/library/Zend/Service/WindowsAzure/Storage/Blob/Stream.php
+++ b/library/Zend/Service/WindowsAzure/Storage/Blob/Stream.php
@@ -145,7 +145,11 @@ class Zend_Service_WindowsAzure_Storage_Blob_Stream
     public function stream_open($path, $mode, $options, &$opened_path)
     {
         $this->_fileName = $path;
-        $this->_temporaryFileName = tempnam(sys_get_temp_dir(), 'azure');
+        // Only use sys_get_temp_dir() if APP_TEMP_DIR is undefined
+        $this->_temporaryFileName = tempnam(
+            defined('APP_TEMP_DIR') ? APP_TEMP_DIR : sys_get_temp_dir(),
+            'azure'
+        );
 
         // Check the file can be opened
         $fh = @fopen($this->_temporaryFileName, $mode);


### PR DESCRIPTION
Restores the temp file changes originally introduced with PCR360-10433.
Temp files should once again only be created in /tmp when AP_TEMP_DIR is undefined
