### PR TITLE
24.2.2 PCR360-11597 PHP8 OCI Lob class changes

### DIFF
--- a/library/Zend/Db/Adapter/Oracle.php
+++ b/library/Zend/Db/Adapter/Oracle.php
@@ -92,7 +92,7 @@ class Zend_Db_Adapter_Oracle extends Zend_Db_Adapter_Abstract
 
     /**
      * Check if LOB field are returned as string
-     * instead of OCI-Lob object
+     * instead of OCILob object
      *
      * @var boolean
      */

--- a/library/Zend/Db/Statement/Oracle.php
+++ b/library/Zend/Db/Statement/Oracle.php
@@ -49,7 +49,7 @@ class Zend_Db_Statement_Oracle extends Zend_Db_Statement
 
     /**
      * Check if LOB field are returned as string
-     * instead of OCI-Lob object
+     * instead of OCILob object
      *
      * @var boolean
      */
@@ -486,9 +486,8 @@ class Zend_Db_Statement_Oracle extends Zend_Db_Statement
         }
 
         if ($this->getLobAsString()) {
-            // instanceof doesn't allow '-', we must use a temporary string
-            $type = 'OCI-Lob';
-            if ($data instanceof $type) {
+            // @see PCR360-11597 In PHP8 the OCI-Lob class was renamed to OCILob
+            if ($data instanceof \OCILob) {
                 $data = $data->read($data->size());
             }
         }

--- a/tests/Zend/Db/Adapter/OracleTest.php
+++ b/tests/Zend/Db/Adapter/OracleTest.php
@@ -426,7 +426,7 @@ class Zend_Db_Adapter_OracleTest extends Zend_Db_Adapter_TestCommon
         $documents = $this->_db->quoteIdentifier('zfdocuments');
         $document_id = $this->_db->quoteIdentifier('doc_id');
         $value = $this->_db->fetchRow("SELECT * FROM $documents WHERE $document_id = 1");
-        $class = 'OCI-Lob';
+        $class = 'OCILob';
         $this->assertTrue($value['doc_clob'] instanceof $class);
         $expected = 'this is the clob that never ends...' .
                     'this is the clob that never ends...' .
@@ -452,7 +452,7 @@ class Zend_Db_Adapter_OracleTest extends Zend_Db_Adapter_TestCommon
         $documents = $this->_db->quoteIdentifier('zfdocuments');
         $document_id = $this->_db->quoteIdentifier('doc_id');
         $value = $this->_db->fetchAssoc("SELECT * FROM $documents WHERE $document_id = 1");
-        $class = 'OCI-Lob';
+        $class = 'OCILob';
         $this->assertTrue($value[1]['doc_clob'] instanceof $class);
         $expected = 'this is the clob that never ends...' .
                     'this is the clob that never ends...' .
@@ -479,7 +479,7 @@ class Zend_Db_Adapter_OracleTest extends Zend_Db_Adapter_TestCommon
         $document_id = $this->_db->quoteIdentifier('doc_id');
         $document_clob = $this->_db->quoteIdentifier('doc_clob');
         $value = $this->_db->fetchOne("SELECT $document_clob FROM $documents WHERE $document_id = 1");
-        $class = 'OCI-Lob';
+        $class = 'OCILob';
         $this->assertTrue($value instanceof $class);
         $expected = 'this is the clob that never ends...' .
                     'this is the clob that never ends...' .


### PR DESCRIPTION
Updates Oracle Db classes to use PHP8 OCILob class instead of legacy 'OCI-Lob'