### PR TITLE
24.2.3 - PCR360-11708 Replace all instances of HTTP_HOST with SERVER_NAME

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pcr/zf1-future",
     "description": "Zend Framework 1. The aim is to keep ZF1 working with the latest PHP versions",
     "type": "library",
-    "version": "24.2.2",
+    "version": "24.2.3",
     "keywords": [
         "framework",
         "zf1"

--- a/library/Zend/Controller/Action/Helper/Redirector.php
+++ b/library/Zend/Controller/Action/Helper/Redirector.php
@@ -210,15 +210,12 @@ class Zend_Controller_Action_Helper_Redirector extends Zend_Controller_Action_He
     protected function _redirect($url)
     {
         if ($this->getUseAbsoluteUri() && !preg_match('#^(https?|ftp)://#', $url)) {
-            $host  = (isset($_SERVER['HTTP_HOST'])?$_SERVER['HTTP_HOST']:'');
+            $host  = (isset($_SERVER['SERVER_NAME'])?$_SERVER['SERVER_NAME']:'');
             $proto = (isset($_SERVER['HTTPS'])&&$_SERVER['HTTPS']!=="off") ? 'https' : 'http';
             $port  = (isset($_SERVER['SERVER_PORT'])?$_SERVER['SERVER_PORT']:80);
             $uri   = $proto . '://' . $host;
             if ((('http' == $proto) && (80 != $port)) || (('https' == $proto) && (443 != $port))) {
-                // do not append if HTTP_HOST already contains port
-                if (strrchr($host, ':') === false) {
-                    $uri .= ':' . $port;
-                }
+                $uri .= ':' . $port;
             }
             $url = $uri . '/' . ltrim($url, '/');
         }

--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -1064,11 +1064,6 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      */
     public function getHttpHost()
     {
-        $host = $this->getServer('HTTP_HOST');
-        if (!empty($host)) {
-            return $host;
-        }
-
         $scheme = $this->getScheme();
         $name   = $this->getServer('SERVER_NAME');
         $port   = $this->getServer('SERVER_PORT');

--- a/library/Zend/Feed/Pubsubhubbub/CallbackAbstract.php
+++ b/library/Zend/Feed/Pubsubhubbub/CallbackAbstract.php
@@ -256,9 +256,6 @@ abstract class Zend_Feed_Pubsubhubbub_CallbackAbstract
      */
     protected function _getHttpHost()
     {
-        if (!empty($_SERVER['HTTP_HOST'])) {
-            return $_SERVER['HTTP_HOST'];
-        }
         $scheme = 'http';
 
         if ($_SERVER['HTTPS'] == 'on') {

--- a/library/Zend/OpenId.php
+++ b/library/Zend/OpenId.php
@@ -98,17 +98,7 @@ class Zend_OpenId
         }
         $url = '';
         $port = '';
-        if (isset($_SERVER['HTTP_HOST'])) {
-            if (($pos = strpos($_SERVER['HTTP_HOST'], ':')) === false) {
-                if (isset($_SERVER['SERVER_PORT'])) {
-                    $port = ':' . $_SERVER['SERVER_PORT'];
-                }
-                $url = $_SERVER['HTTP_HOST'];
-            } else {
-                $url = substr($_SERVER['HTTP_HOST'], 0, $pos);
-                $port = substr($_SERVER['HTTP_HOST'], $pos);
-            }
-        } else if (isset($_SERVER['SERVER_NAME'])) {
+        if (isset($_SERVER['SERVER_NAME'])) {
             $url = $_SERVER['SERVER_NAME'];
             if (isset($_SERVER['SERVER_PORT'])) {
                 $port = ':' . $_SERVER['SERVER_PORT'];

--- a/library/Zend/Soap/AutoDiscover.php
+++ b/library/Zend/Soap/AutoDiscover.php
@@ -253,10 +253,11 @@ class Zend_Soap_AutoDiscover implements Zend_Server_Interface
      */
     protected function getHostName()
     {
-        if(isset($_SERVER['HTTP_HOST'])) {
-            $host = $_SERVER['HTTP_HOST'];
-        } else {
-            $host = $_SERVER['SERVER_NAME'];
+        $host  = $_SERVER['SERVER_NAME'] ?? '';
+        $proto = empty($_SERVER['HTTPS']) ? 'http' : 'https';
+        $port  = $_SERVER['SERVER_PORT'] ?? 80;
+        if ((('http' === $proto) && (80 !== $port)) || (('https' === $proto) && (443 !== $port))) {
+            $host .= ':' . $port;
         }
         return $host;
     }

--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -64,9 +64,7 @@ class Zend_View_Helper_ServerUrl
         }
         $this->setScheme($scheme);
 
-        if (isset($_SERVER['HTTP_HOST']) && !empty($_SERVER['HTTP_HOST'])) {
-            $this->setHost($_SERVER['HTTP_HOST']);
-        } else if (isset($_SERVER['SERVER_NAME'], $_SERVER['SERVER_PORT'])) {
+        if (isset($_SERVER['SERVER_NAME'], $_SERVER['SERVER_PORT'])) {
             $name = $_SERVER['SERVER_NAME'];
             $port = $_SERVER['SERVER_PORT'];
 


### PR DESCRIPTION
Eliminates HTTP_HOST header usage in deference to SERVER_NAME(:SERVER_PORT) to avoid host header injection